### PR TITLE
feat: turn off leaderboard

### DIFF
--- a/app/src/main/java/io/github/drp08/studypal/presentation/navigation/BottomNavItem.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/navigation/BottomNavItem.kt
@@ -12,6 +12,7 @@ import io.github.drp08.studypal.presentation.screens.FlowerViewScreen
 import io.github.drp08.studypal.presentation.screens.HomeScreen
 import io.github.drp08.studypal.presentation.screens.LeaderboardScreen
 import io.github.drp08.studypal.presentation.screens.MonthlyCalendarScreen
+import io.github.drp08.studypal.presentation.screens.NoLeaderboardFlowerGarden
 import io.github.drp08.studypal.presentation.screens.ProfileScreen
 import io.github.drp08.studypal.presentation.screens.WeeklyCalendarScreen
 
@@ -21,11 +22,11 @@ sealed class BottomNavItem(
     val screen: Screen,
 ) {
     companion object {
-        fun values() = listOf(Home, Calendar, Profile, LeaderBoard)
+        fun values() = listOf(Home, Calendar, LeaderBoard, Profile)
     }
 
     data object Home : BottomNavItem("Home", Icons.Default.Home, HomeScreen)
     data object Calendar : BottomNavItem("Calendar", Icons.Default.DateRange, MonthlyCalendarScreen)
     data object Profile : BottomNavItem("Profile", Icons.Default.Person, ProfileScreen)
-    data object LeaderBoard : BottomNavItem("Leaderboard", Icons.Default.Star, LeaderboardScreen)
+    data object LeaderBoard : BottomNavItem("Leaderboard", Icons.Default.Star, NoLeaderboardFlowerGarden)
 }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/navigation/BottomNavItem.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/navigation/BottomNavItem.kt
@@ -28,5 +28,5 @@ sealed class BottomNavItem(
     data object Home : BottomNavItem("Home", Icons.Default.Home, HomeScreen)
     data object Calendar : BottomNavItem("Calendar", Icons.Default.DateRange, MonthlyCalendarScreen)
     data object Profile : BottomNavItem("Profile", Icons.Default.Person, ProfileScreen)
-    data object LeaderBoard : BottomNavItem("Leaderboard", Icons.Default.Star, NoLeaderboardFlowerGarden)
+    data object LeaderBoard : BottomNavItem("Leaderboard", Icons.Default.Star, LeaderboardScreen)
 }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
@@ -32,11 +32,12 @@ object FlowerViewScreen : Screen {
     @Composable
     override fun Content() {
         val viewModel: FlowerViewModel = viewModel()
+        val viewModel2 : LeaderboardViewModel = viewModel()
         val boxCount by viewModel.boxCount.collectAsState()
         val flowerCounts by viewModel.flowerCounts.collectAsState()
         val names by viewModel.names.collectAsState()
 
-        var showFlowerGarden by remember { mutableStateOf(true) }
+        val showFlowerGarden by viewModel2.isLeaderboard.collectAsState()
 
         Column(
             modifier = Modifier
@@ -49,11 +50,11 @@ object FlowerViewScreen : Screen {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center
             ) {
-                TextButton(onClick = { showFlowerGarden = true }) {
+                TextButton(onClick = {}) {
                     Text("Flower Garden")
                 }
                 Spacer(modifier = Modifier.width(16.dp))
-                TextButton(onClick = { showFlowerGarden = false }) {
+                TextButton(onClick = { viewModel2.toggleLeaderboardAndFlowers() }) {
                     Text("Leaderboard")
                 }
             }
@@ -63,7 +64,6 @@ object FlowerViewScreen : Screen {
                 FlowerGardenScreen(boxCount, flowerCounts, names)
             }
             else {
-                val viewModel2: LeaderboardViewModel = viewModel()
                 val leaderboardItems by viewModel2.leaderboardItems.collectAsState()
                 LeaderboardScreen.LeaderboardScreen(leaderboardItems)
             }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
@@ -148,7 +148,7 @@ object FlowerViewScreen : Screen {
     }
 
     @Composable
-    private fun generateFlowerCenters(flowerCount: Int, boxWidth: Dp, boxHeight: Dp): List<Offset> {
+    fun generateFlowerCenters(flowerCount: Int, boxWidth: Dp, boxHeight: Dp): List<Offset> {
         val boxWidthPx = boxWidth.toPx()
         val boxHeightPx = boxHeight.toPx()
         val maxPetalRadius = 10.dp.toPx()
@@ -200,13 +200,10 @@ object FlowerViewScreen : Screen {
         val green = color.green
         val blue = color.blue
 
-        // Exclude all shades of grey
         if (red == green && green == blue) return true
 
-        // Exclude all shades of green
         if (green > red && green > blue) return true
 
-        // Exclude all shades of brown
         if (red > green && green > blue) return true
 
         return false

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/FlowerGardenScreen.kt
@@ -65,7 +65,7 @@ object FlowerViewScreen : Screen {
             else {
                 val viewModel2: LeaderboardViewModel = viewModel()
                 val leaderboardItems by viewModel2.leaderboardItems.collectAsState()
-                io.github.drp08.studypal.presentation.screens.LeaderboardScreen.LeaderboardScreen(leaderboardItems)
+                LeaderboardScreen.LeaderboardScreen(leaderboardItems)
             }
         }
     }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
@@ -19,9 +19,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,13 +34,16 @@ import io.github.drp08.studypal.presentation.viewmodels.FlowerViewModel
 import io.github.drp08.studypal.presentation.viewmodels.LeaderboardItem
 import io.github.drp08.studypal.presentation.viewmodels.LeaderboardViewModel
 
+
 object LeaderboardScreen : Screen {
     @Composable
     override fun Content() {
         val viewModel: LeaderboardViewModel = viewModel()
         val leaderboardItems by viewModel.leaderboardItems.collectAsState()
-        var showLeaderboard by remember { mutableStateOf(true) }
-        var showSingleGarden by remember { mutableStateOf(true) }
+        val showLeaderboard by viewModel.isLeaderboard.collectAsState()
+        val showSingleGarden by viewModel.isLeaderboardEnabled.collectAsState()
+        val isLeaderboard by viewModel.currentlyInLeaderBoardView.collectAsState()
+        val isFlowerView by viewModel.currentlyInFlowerView.collectAsState()
 
         Column(
             modifier = Modifier
@@ -54,7 +54,7 @@ object LeaderboardScreen : Screen {
         ) {
             Switch(
                 checked = showSingleGarden,
-                onCheckedChange = { showSingleGarden = it },
+                onCheckedChange = { viewModel.toggleLeaderboard() },
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = Color(0xFF258a40),
                     checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
@@ -64,17 +64,18 @@ object LeaderboardScreen : Screen {
 
             )
             if (!showSingleGarden) {
+                
                 SingleGardenScreen()
             } else {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
-                    TextButton(onClick = { showLeaderboard = true }) {
+                    TextButton(onClick = { if(!isLeaderboard) {viewModel.toggleLeaderboardAndFlowers()} }) {
                         Text("Leaderboard")
                     }
                     Spacer(modifier = Modifier.width(16.dp))
-                    TextButton(onClick = { showLeaderboard = false }) {
+                    TextButton(onClick = { if(!isFlowerView) {viewModel.toggleLeaderboardAndFlowers()} }) {
                         Text("FlowerGarden")
                     }
                 }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.core.screen.Screen
 import coil.compose.AsyncImage
+import io.github.drp08.studypal.presentation.screens.NoLeaderboardFlowerGarden.SingleGardenScreen
 import io.github.drp08.studypal.presentation.viewmodels.FlowerViewModel
 import io.github.drp08.studypal.presentation.viewmodels.LeaderboardItem
 import io.github.drp08.studypal.presentation.viewmodels.LeaderboardViewModel
@@ -39,6 +41,7 @@ object LeaderboardScreen : Screen {
         val viewModel: LeaderboardViewModel = viewModel()
         val leaderboardItems by viewModel.leaderboardItems.collectAsState()
         var showLeaderboard by remember { mutableStateOf(true) }
+        var showSingleGarden by remember { mutableStateOf(true) }
 
         Column(
             modifier = Modifier
@@ -47,33 +50,40 @@ object LeaderboardScreen : Screen {
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                TextButton(onClick = { showLeaderboard = true }) {
-                    Text("Leaderboard")
-                }
-                Spacer(modifier = Modifier.width(16.dp))
-                TextButton(onClick = { showLeaderboard = false }) {
-                    Text("FlowerGarden")
-                }
-            }
-            Spacer(modifier = Modifier.height(16.dp))
-
-            if (showLeaderboard) {
-                LeaderboardScreen(leaderboardItems = leaderboardItems)
+            Switch(
+                checked = showSingleGarden,
+                onCheckedChange = { showSingleGarden = it }
+            )
+            if (!showSingleGarden) {
+                SingleGardenScreen()
             } else {
-                val viewModel2: FlowerViewModel = viewModel()
-                val boxCount by viewModel2.boxCount.collectAsState()
-                val flowerCounts by viewModel2.flowerCounts.collectAsState()
-                val names by viewModel2.names.collectAsState()
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    TextButton(onClick = { showLeaderboard = true }) {
+                        Text("Leaderboard")
+                    }
+                    Spacer(modifier = Modifier.width(16.dp))
+                    TextButton(onClick = { showLeaderboard = false }) {
+                        Text("FlowerGarden")
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                if (showLeaderboard) {
+                    LeaderboardScreen(leaderboardItems = leaderboardItems)
+                } else {
+                    val viewModel2: FlowerViewModel = viewModel()
+                    val boxCount by viewModel2.boxCount.collectAsState()
+                    val flowerCounts by viewModel2.flowerCounts.collectAsState()
+                    val names by viewModel2.names.collectAsState()
 
-                FlowerViewScreen.FlowerGardenScreen(
-                    boxCount = boxCount,
-                    flowerCounts = flowerCounts,
-                    names = names
-                )
+                    FlowerViewScreen.FlowerGardenScreen(
+                        boxCount = boxCount,
+                        flowerCounts = flowerCounts,
+                        names = names
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/LeaderboardScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -52,7 +54,14 @@ object LeaderboardScreen : Screen {
         ) {
             Switch(
                 checked = showSingleGarden,
-                onCheckedChange = { showSingleGarden = it }
+                onCheckedChange = { showSingleGarden = it },
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = Color(0xFF258a40),
+                    checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
+                    uncheckedThumbColor = Color.Red,
+                    uncheckedTrackColor = MaterialTheme.colorScheme.secondaryContainer
+                )
+
             )
             if (!showSingleGarden) {
                 SingleGardenScreen()

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
@@ -3,8 +3,14 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -14,7 +20,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.core.screen.Screen
+import io.github.drp08.studypal.presentation.viewmodels.LeaderboardViewModel
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
@@ -23,6 +31,11 @@ import kotlin.random.Random
 object NoLeaderboardFlowerGarden : Screen {
     @Composable
     override fun Content() {
+        SingleGardenScreen()
+    }
+
+    @Composable
+    fun SingleGardenScreen() {
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
@@ -1,0 +1,146 @@
+package io.github.drp08.studypal.presentation.screens
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+
+
+object NoLeaderboardFlowerGarden : Screen {
+    @Composable
+    override fun Content() {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "You have turned off the leaderboard, your friends can't see how you are doing. Turn it back on to continue",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(16.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            BoxWithFlowers(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
+                    .padding(8.dp),
+                flowers = generateFlowerCenters(10, 600.dp - 300.dp, 600.dp - 300.dp)
+            )
+        }
+    }
+
+    @Composable
+    fun generateFlowerCenters(flowerCount: Int, boxWidth: Dp, boxHeight: Dp): List<Offset> {
+        val boxWidthPx = boxWidth.toPx()
+        val boxHeightPx = boxHeight.toPx()
+        val maxPetalRadius = 15.dp.toPx()
+
+        val imagePadding = 16.dp.toPx()
+
+        val maxX = boxWidthPx - imagePadding
+        val maxY = boxHeightPx - imagePadding
+
+        return List(flowerCount) {
+            val x = Random.nextFloat() * (maxX - 2 * maxPetalRadius) + maxPetalRadius
+            val y = Random.nextFloat() * (maxY - 2 * maxPetalRadius) + maxPetalRadius
+            Offset(x, y)
+        }
+    }
+
+    @Composable
+    fun BoxWithFlowers(modifier: Modifier, flowers: List<Offset>) {
+        Box(modifier = modifier.background(Color.Green)) {
+            FlowerViewScreen.InternetImageBackground(
+                url = "https://media.istockphoto.com/id/1287348587/vector/green-lawn-view-from-top-grass-and-bushes-summer-field.jpg?s=612x612&w=0&k=20&c=beeLyqiIditNPu-zQSZEznVz40bNEphK9Y6pcYHQWLk="
+            )
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                drawFlowerGarden(flowers)
+            }
+        }
+
+    }
+
+    private fun DrawScope.drawFlowerGarden(flowers: List<Offset>) {
+        for (position in flowers) {
+            drawFlower(position)
+        }
+    }
+
+    private fun DrawScope.drawFlower(position: Offset) {
+        val petalRadius = 15.dp.toPx()
+        val flowerRadius = 7.dp.toPx()
+        val petalColor = randomColor()
+        val centerColor = randomColor()
+
+        for (i in 0..4) {
+            val angle = (72 * i).toFloat()
+            val petalX = position.x + petalRadius * cos(Math.toRadians(angle.toDouble())).toFloat()
+            val petalY = position.y + petalRadius * sin(Math.toRadians(angle.toDouble())).toFloat()
+
+            drawCircle(
+                color = petalColor,
+                radius = petalRadius / 2,
+                center = Offset(petalX, petalY)
+            )
+        }
+        drawCircle(
+            color = centerColor,
+            radius = flowerRadius,
+            center = position
+        )
+    }
+
+    private fun isExcludedColor(color: Color): Boolean {
+        val red = color.red
+        val green = color.green
+        val blue = color.blue
+
+        if (red == green && green == blue) return true
+
+        if (green > red && green > blue) return true
+
+        if (red > green && green > blue) return true
+
+        return false
+    }
+
+    private fun randomColor(): Color {
+        while (true) {
+            val color = Color(
+                red = Random.nextFloat(),
+                green = Random.nextFloat(),
+                blue = Random.nextFloat(),
+                alpha = 1f
+            )
+            if (!isExcludedColor(color)) {
+                return color
+            }
+        }
+    }
+
+    @Composable
+    fun Dp.toPx(): Float {
+        val density = LocalDensity.current
+        return with(density) { this@toPx.toPx() }
+    }
+
+}
+

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
@@ -3,14 +3,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -20,9 +14,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.core.screen.Screen
-import io.github.drp08.studypal.presentation.viewmodels.LeaderboardViewModel
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random

--- a/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/screens/NoLeaderboardFlowerGarden.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -14,7 +16,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import cafe.adriel.voyager.core.screen.Screen
+import io.github.drp08.studypal.presentation.viewmodels.SingleGardenViewModel
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
@@ -28,6 +32,9 @@ object NoLeaderboardFlowerGarden : Screen {
 
     @Composable
     fun SingleGardenScreen() {
+        val viewModel: SingleGardenViewModel = viewModel()
+        val flowerCount by viewModel.flowerCount.collectAsState()
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -47,7 +54,7 @@ object NoLeaderboardFlowerGarden : Screen {
                     .fillMaxWidth()
                     .aspectRatio(1f)
                     .padding(8.dp),
-                flowers = generateFlowerCenters(10, 600.dp - 300.dp, 600.dp - 300.dp)
+                flowers = generateFlowerCenters(flowerCount, 600.dp - 300.dp, 600.dp - 300.dp)
             )
         }
     }

--- a/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/LeaderboardViewModel.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/LeaderboardViewModel.kt
@@ -19,6 +19,18 @@ class LeaderboardViewModel : ViewModel() {
         LeaderboardItem("Bruce Wayne", 900)
     )
 
+    private val _isLeaderboardEnabled = MutableStateFlow(true)
+    var isLeaderboardEnabled: StateFlow<Boolean> = _isLeaderboardEnabled
+
+    private val _isLeaderboard = MutableStateFlow(true)
+    var isLeaderboard: StateFlow<Boolean> = _isLeaderboard
+
+    private val _currentlyInLeaderBoardView = MutableStateFlow(true)
+    var currentlyInLeaderBoardView: StateFlow<Boolean> = _currentlyInLeaderBoardView
+
+    private val _currentlyInFlowerView = MutableStateFlow(false)
+    var currentlyInFlowerView: StateFlow<Boolean> = _currentlyInFlowerView
+
     private val _leaderboardItems = MutableStateFlow(emptyList<LeaderboardItem>())
     val leaderboardItems: StateFlow<List<LeaderboardItem>> = _leaderboardItems.asStateFlow()
 
@@ -26,6 +38,16 @@ class LeaderboardViewModel : ViewModel() {
         viewModelScope.launch {
             _leaderboardItems.value = defaultLeaderboardItems
         }
+    }
+
+    fun toggleLeaderboard() {
+        _isLeaderboardEnabled.value = !_isLeaderboardEnabled.value
+    }
+
+    fun toggleLeaderboardAndFlowers() {
+        _isLeaderboard.value = !_isLeaderboard.value
+        _currentlyInLeaderBoardView.value = !_currentlyInLeaderBoardView.value
+        _currentlyInFlowerView.value = !_currentlyInFlowerView.value
     }
 
     fun addLeaderboardItem(item: LeaderboardItem) {

--- a/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/SingleGardenViewModel.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/SingleGardenViewModel.kt
@@ -1,0 +1,4 @@
+package io.github.drp08.studypal.presentation.viewmodels
+
+class SingleGardenViewModel {
+}

--- a/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/SingleGardenViewModel.kt
+++ b/app/src/main/java/io/github/drp08/studypal/presentation/viewmodels/SingleGardenViewModel.kt
@@ -1,4 +1,22 @@
 package io.github.drp08.studypal.presentation.viewmodels
 
-class SingleGardenViewModel {
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class SingleGardenViewModel : ViewModel() {
+
+    private val _isLeaderboardEnabled = MutableStateFlow(true)
+    val isLeaderboardEnabled: StateFlow<Boolean> = _isLeaderboardEnabled
+
+    private val _flowerCount = MutableStateFlow(10)
+    val flowerCount: StateFlow<Int> = _flowerCount
+
+    fun toggleLeaderboard() {
+        _isLeaderboardEnabled.value = !_isLeaderboardEnabled.value
+    }
+
+    fun setFlowerCount(count: Int) {
+        _flowerCount.value = count
+    }
 }


### PR DESCRIPTION
### Issue link

Closes #32 

### Description

I have implemented the ability to turn the leaderboard screen on and off and store the last saved view and return to that when re entered. 

### Checks

- [x] The PR title starts with `feat:`, `fix:`, `chore:`, `style:`, etc.
- [x] The PR links to the given issue.
- [x] You've labelled "wip" or "needs review" to this PR.
- [x] You have moved your Issue card on the project to the appropriate location.

### Any other supporting description or media with this PR

*No Response*